### PR TITLE
fix: remove html entities from url given that now produce error 500 on omie.es

### DIFF
--- a/datasources/omie/omie_operations.py
+++ b/datasources/omie/omie_operations.py
@@ -58,7 +58,7 @@ def get_historical_hour_price(engine, verbose=2, dry_run=False):
 
     filetype = 'marginalpdbc'
     hist_files = get_file_list(filetype)
-    file_base_url = f'https://www.omie.es/es/file-download?parents%5B0%5D={filetype}&filename='
+    file_base_url = f'https://www.omie.es/es/file-download?parents={filetype}&filename='
 
     total = len(hist_files['Nombre'])
 
@@ -92,7 +92,7 @@ def update_latest_hour_price(engine, verbose=2, dry_run=False):
 
     filetype = 'marginalpdbc'
     hist_files = get_file_list(filetype)
-    file_base_url = f'https://www.omie.es/es/file-download?parents%5B0%5D={filetype}&filename='
+    file_base_url = f'https://www.omie.es/es/file-download?parents={filetype}&filename='
 
     file_name = hist_files['Nombre'][0]
     pathfile = file_base_url + file_name
@@ -124,7 +124,7 @@ def update_historical_hour_price(engine, verbose=2, dry_run=False):
 
     filetype = 'marginalpdbc'
     hist_files = get_file_list(filetype)
-    file_base_url = f'https://www.omie.es/es/file-download?parents%5B0%5D={filetype}&filename='
+    file_base_url = f'https://www.omie.es/es/file-download?parents={filetype}&filename='
 
     file_name = hist_files['Nombre'][0]
     pathfile = file_base_url + file_name
@@ -193,7 +193,7 @@ def update_energy_buy_fromweb(engine, verbose=2, dry_run=False):
 
     filetype = 'pdbc'
     hist_files = get_file_list(filetype)
-    file_base_url = f'https://www.omie.es/es/file-download?parents%5B0%5D={filetype}&filename='
+    file_base_url = f'https://www.omie.es/es/file-download?parents={filetype}&filename='
 
     file_name = hist_files['Nombre'][0]
 

--- a/datasources/omie/omie_update_last_hour_price.py
+++ b/datasources/omie/omie_update_last_hour_price.py
@@ -36,7 +36,7 @@ def get_files(engine, filetype, potential_missing):
         print(f'No {filetype} new files available.')
         exit()
 
-    base_url = f'https://www.omie.es/es/file-download?parents%5B0%5D={filetype}&filename='
+    base_url = f'https://www.omie.es/es/file-download?parents={filetype}&filename='
 
     try:
         dfs = [


### PR DESCRIPTION
We had persistent failed task error 500 on omie.es. Upon debugging, we deem removing the html entities fixes the problem.

## Description

Single phrase summary of the pull request

## Changes

- Comprehensive list of changes (effect, not process)

## Checklist

Justify any unchecked point:

- [ ] Changed code is covered by tests.
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

## Observations

## Please, review

- List of things authors emphasize to review

## How to check the new features

## Deploy notes


